### PR TITLE
test: improve mutation score from 56% to ~90%

### DIFF
--- a/test/commands/sfpc/combine.test.ts
+++ b/test/commands/sfpc/combine.test.ts
@@ -84,16 +84,6 @@ describe('sfpc combine', () => {
     expect(testPackage).toEqual(baselinePackage);
   });
 
-  it('uses default packageFiles when none provided', async () => {
-    const warnings: string[] = [];
-    const path = await combinePackages({
-      directories: [packageDir],
-      combinedPackage: outputPackage,
-      warn: (msg) => warnings.push(msg),
-    });
-
-    expect(path).toBe(outputPackage);
-  });
   it('uses default output path when combinedPackage is not specified', async () => {
     const warnings: string[] = [];
     const path = await combinePackages({
@@ -134,7 +124,90 @@ describe('sfpc combine', () => {
 
     expect(path).toBe(outputPackage);
     expect(warnings).toHaveLength(0);
+    const content = await readFile(outputPackage, 'utf-8');
+    expect(content).not.toContain('<version>');
   });
+
+  it('output without noApiVersion includes xml declaration and version tag', async () => {
+    const warnings: string[] = [];
+    await combinePackages({
+      packageFiles: [package2],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    const content = await readFile(outputPackage, 'utf-8');
+    expect(content.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n')).toBe(true);
+    expect(content).toContain('<version>59.0</version>');
+  });
+
+  it('selects the maximum API version across packages', async () => {
+    const abcPackage = resolve('test/samples/dir_sample/package-abc-object.xml');
+    const warnings: string[] = [];
+    await combinePackages({
+      packageFiles: [package2, abcPackage],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    const content = await readFile(outputPackage, 'utf-8');
+    expect(content).toContain('<version>59.0</version>');
+  });
+
+  it('sorts types with CustomObject first and non-CustomObject types alphabetically', async () => {
+    const warnings: string[] = [];
+    await combinePackages({
+      packageFiles: [package1, package2, package3],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    const content = await readFile(outputPackage, 'utf-8');
+    const customObjectIdx = content.indexOf('<name>CustomObject</name>');
+    const customLabelIdx = content.indexOf('<name>CustomLabel</name>');
+    const standardValueSetIdx = content.indexOf('<name>StandardValueSet</name>');
+    expect(customObjectIdx).toBeGreaterThan(-1);
+    expect(customObjectIdx).toBeLessThan(customLabelIdx);
+    expect(customObjectIdx).toBeLessThan(standardValueSetIdx);
+    expect(customLabelIdx).toBeLessThan(standardValueSetIdx);
+  });
+
+  it('deduplicates members that appear in multiple input packages', async () => {
+    const warnings: string[] = [];
+    await combinePackages({
+      packageFiles: [package1, package2],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    const content = await readFile(outputPackage, 'utf-8');
+    const accountMatches = content.match(/<members>Account<\/members>/g);
+    expect(accountMatches).toHaveLength(1);
+  });
+
+  it('sorts members alphabetically within each type', async () => {
+    const warnings: string[] = [];
+    // package2 first so Case is inserted before Account in processing order
+    await combinePackages({
+      packageFiles: [package2, package1],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    const content = await readFile(outputPackage, 'utf-8');
+    const accountIdx = content.indexOf('<members>Account</members>');
+    const caseIdx = content.indexOf('<members>Case</members>');
+    expect(accountIdx).toBeGreaterThan(-1);
+    expect(accountIdx).toBeLessThan(caseIdx);
+  });
+
+  it('uses default packageFiles when none provided and only emits expected warnings', async () => {
+    const warnings: string[] = [];
+    const path = await combinePackages({
+      directories: [packageDir],
+      combinedPackage: outputPackage,
+      warn: (msg) => warnings.push(msg),
+    });
+    expect(path).toBe(outputPackage);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Invalid or empty package.xml');
+  });
+
   it('returns no warnings when files is null (skips processing)', async () => {
     const warnings = await mergePackageXmlFiles(null, 'package.xml', null, false);
     expect(warnings).toEqual([]);

--- a/test/core/determineApiVersion.test.ts
+++ b/test/core/determineApiVersion.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { determineApiVersion } from '../../src/core/determineApiVersion.js';
+
+describe('determineApiVersion', () => {
+  it('returns 0.0 when noApiVersion is true', () => {
+    expect(determineApiVersion(['61.0'], null, true)).toBe('0.0');
+  });
+
+  it('noApiVersion takes priority over userApiVersion', () => {
+    expect(determineApiVersion([], '60.0', true)).toBe('0.0');
+  });
+
+  it('returns userApiVersion when provided (not null)', () => {
+    expect(determineApiVersion(['59.0', '61.0'], '60.0', false)).toBe('60.0');
+  });
+
+  it('returns maximum version from apiVersions when userApiVersion is null', () => {
+    expect(determineApiVersion(['59.0', '61.0', '60.0'], null, false)).toBe('61.0');
+  });
+
+  it('returns initial 0.0 when apiVersions is empty and userApiVersion is null', () => {
+    expect(determineApiVersion([], null, false)).toBe('0.0');
+  });
+
+  it('returns the single version in the array', () => {
+    expect(determineApiVersion(['59.0'], null, false)).toBe('59.0');
+  });
+
+  it('picks max over a lower initial accumulator', () => {
+    expect(determineApiVersion(['61.0', '59.0'], null, false)).toBe('61.0');
+  });
+});

--- a/test/core/writePackage.test.ts
+++ b/test/core/writePackage.test.ts
@@ -1,0 +1,52 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import type { PackageManifestObject } from '@salesforce/source-deploy-retrieve';
+
+import { writePackage } from '../../src/core/writePackage.js';
+import { sfXmlns } from '../../src/utils/constants.js';
+
+describe('writePackage', () => {
+  const outputPath = resolve('package.xml');
+
+  const makePackage = (version: string): PackageManifestObject => ({
+    Package: {
+      '@_xmlns': sfXmlns,
+      types: [],
+      version,
+    },
+  });
+
+  it('writes xml declaration header', async () => {
+    await writePackage(makePackage('59.0'), outputPath);
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n')).toBe(true);
+  });
+
+  it('preserves non-zero version in output', async () => {
+    await writePackage(makePackage('59.0'), outputPath);
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).toContain('<version>59.0</version>');
+  });
+
+  it('removes version element entirely when version is 0.0', async () => {
+    await writePackage(makePackage('0.0'), outputPath);
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).not.toContain('<version>');
+    expect(content).not.toContain('0.0');
+  });
+
+  it('does not corrupt content when stripping 0.0 version', async () => {
+    await writePackage(makePackage('0.0'), outputPath);
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).toContain('<Package');
+    expect(content).toContain('</Package>');
+  });
+
+  it('does not strip version when version is not 0.0', async () => {
+    await writePackage(makePackage('61.0'), outputPath);
+    const content = await readFile(outputPath, 'utf-8');
+    expect(content).not.toContain('<version>0.0</version>');
+    expect(content).toContain('<version>61.0</version>');
+  });
+});

--- a/test/utils/findFilesInDirectory.test.ts
+++ b/test/utils/findFilesInDirectory.test.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+
+import { findFilesInDirectory } from '../../src/utils/findFilesinDirectory.js';
+
+describe('findFilesInDirectory', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'sfpc-test-'));
+    await writeFile(join(tempDir, 'package.xml'), '<xml/>');
+    await writeFile(join(tempDir, 'ignore-me.txt'), 'text content');
+    await mkdir(join(tempDir, 'subdir'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns only xml files, excluding non-xml files and subdirectories', async () => {
+    const { files, warnings } = await findFilesInDirectory([tempDir]);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/package\.xml$/);
+    expect(warnings).toEqual([]);
+  });
+
+  it('returns initial-empty files array (not pre-populated)', async () => {
+    const tempDir2 = await mkdtemp(join(tmpdir(), 'sfpc-empty-'));
+    try {
+      const { files } = await findFilesInDirectory([tempDir2]);
+      expect(files).toEqual([]);
+    } finally {
+      await rm(tempDir2, { recursive: true, force: true });
+    }
+  });
+
+  it('returns initial-empty warnings array (not pre-populated)', async () => {
+    const { warnings } = await findFilesInDirectory([tempDir]);
+    expect(warnings).toEqual([]);
+  });
+
+  it('adds warning for non-existent directory and returns no files', async () => {
+    const missing = join(tempDir, 'does-not-exist');
+    const { files, warnings } = await findFilesInDirectory([missing]);
+    expect(files).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toBe(`Failed to read directory ${missing}`);
+  });
+
+  it('processes multiple directories and collects all xml files', async () => {
+    const tempDir2 = await mkdtemp(join(tmpdir(), 'sfpc-test2-'));
+    try {
+      await writeFile(join(tempDir2, 'another.xml'), '<xml/>');
+      const { files, warnings } = await findFilesInDirectory([tempDir, tempDir2]);
+      expect(files).toHaveLength(2);
+      expect(warnings).toEqual([]);
+    } finally {
+      await rm(tempDir2, { recursive: true, force: true });
+    }
+  });
+
+  it('collects warnings for bad directories while still processing good ones', async () => {
+    const missing = join(tempDir, 'does-not-exist');
+    const { files, warnings } = await findFilesInDirectory([tempDir, missing]);
+    expect(files).toHaveLength(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Failed to read directory');
+    expect(warnings[0]).toContain('does-not-exist');
+  });
+
+  it('returns empty result for empty directory', async () => {
+    const emptyDir = await mkdtemp(join(tmpdir(), 'sfpc-empty-'));
+    try {
+      const { files, warnings } = await findFilesInDirectory([emptyDir]);
+      expect(files).toEqual([]);
+      expect(warnings).toEqual([]);
+    } finally {
+      await rm(emptyDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/utils/getConcurrencyThreshold.test.ts
+++ b/test/utils/getConcurrencyThreshold.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { getConcurrencyThreshold } from '../../src/utils/getConcurrencyThreshold.js';
+
+describe('getConcurrencyThreshold', () => {
+  it('returns a value no greater than 6', () => {
+    expect(getConcurrencyThreshold()).toBeLessThanOrEqual(6);
+  });
+
+  it('returns a positive number', () => {
+    expect(getConcurrencyThreshold()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Add 4 new unit test files targeting previously untested functions (`determineApiVersion`, `writePackage`, `findFilesInDirectory`, `getConcurrencyThreshold`)
- Extend `combine.test.ts` with content-level assertions (reading output XML) to kill surviving mutants in `mergePackageXmlFiles` and `combinePackages`

## Mutants killed per file

| File | Before | Targeted kills |
|------|--------|---------------|
| `determineApiVersion.ts` | 0% | 13/14 (1 equivalent: `>=` vs `>`) |
| `writePackage.ts` | 6% | ~13/15 (1 equivalent: `if (true)` for non-zero versions) |
| `findFilesinDirectory.ts` | 56% | 8/8 |
| `getConcurrencyThreshold.ts` | 50% | 1/1 |
| `mergePackageXmlFiles.ts` | 79% | type sort order, member dedup, member sort |
| `combinePackages.ts` | 57% | default-value mutations; 4 directory-condition mutations are equivalent |

## Test plan

- [x] All 52 tests pass locally (`npx vitest run`)
- [ ] Mutation score verified via CI full-run workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)