### PR TITLE
feat(combine): add dry-run mode, conflict reporting, and combine stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Merge multiple `package.xml` manifests into one. Use it in CI/CD pipelines to co
     - [`sf sfpc combine`](#sf-sfpc-combine)
   - [How it works](#how-it-works)
   - [Example](#example)
+  - [Dry Run, Stats, and Conflict Reporting](#dry-run-stats-and-conflict-reporting)
   - [Invalid Manifests](#invalid-manifests)
   - [Issues](#issues)
   - [License](#license)
@@ -58,7 +59,7 @@ Combine Salesforce manifest files into one `package.xml`.
 
 ```
 USAGE
-  $ sf sfpc combine [-f <value>] [-d <value>] [-c <value>] [-v <value>] [-n] [--json]
+  $ sf sfpc combine [-f <value>] [-d <value>] [-c <value>] [-v <value>] [-n] [--dry-run] [--json]
 
 FLAGS
   -f, --package-file=<value>     Path to a package.xml file. Can be repeated.
@@ -66,6 +67,8 @@ FLAGS
   -c, --combined-package=<value> Path for the output file. Default: package.xml
   -v, --api-version=<value>      API version for the combined package (e.g. 62.0).
   -n, --no-api-version           Omit the <version> element in the output.
+  --dry-run                      Preview the combined package summary (types, members, duplicates)
+                                  without writing an output file.
 
 GLOBAL FLAGS
   --json  Output as JSON.
@@ -85,6 +88,9 @@ sf sfpc combine -f pack1.xml -f pack2.xml -v "62.0" -c package.xml
 
 # No version in output
 sf sfpc combine -f pack1.xml -f pack2.xml -n -c package.xml
+
+# Preview only, no file written
+sf sfpc combine -f pack1.xml -f pack2.xml --dry-run
 ```
 
 ---
@@ -150,6 +156,64 @@ sf sfpc combine -f "package1.xml" -f "package2.xml" -c "package.xml"
 ```
 
 Highest input version (`62.0`) is used.
+
+---
+
+## Dry Run, Stats, and Conflict Reporting
+
+Use `--dry-run` to preview a combine — metadata type/member counts, cross-file duplicate members, and the resolved API version — without writing an output file. Useful for logging what a merge would produce in a CI pipeline before committing to it.
+
+```bash
+sf sfpc combine -f package1.xml -f package2.xml -f package3.xml --dry-run
+```
+
+```
+Input files: 3
+
+Metadata Types: 3
+Members: 4
+
+Duplicate members removed: 1
+API Version: 59.0
+
+Duplicates:
+  CustomObject: Account
+    package1.xml
+    package2.xml
+
+Output would contain:
+  CustomLabel ...... 1
+  CustomObject ...... 2
+  StandardValueSet ...... 1
+
+No file written.
+```
+
+Duplicate members (same metadata type + member name found in more than one input file) are always deduplicated in the final output, whether or not `--dry-run` is used; the `Duplicates:` section just tells you which files caused the removal.
+
+Add `--json` (with or without `--dry-run`) to get the same data as structured output, e.g. for CI dashboards:
+
+```json
+{
+  "status": 0,
+  "result": {
+    "path": null,
+    "dryRun": true,
+    "filesProcessed": 3,
+    "types": 3,
+    "members": 4,
+    "duplicatesRemoved": 1,
+    "duplicates": [
+      { "type": "CustomObject", "member": "Account", "files": ["package1.xml", "package2.xml"] }
+    ],
+    "membersByType": { "CustomLabel": 1, "CustomObject": 2, "StandardValueSet": 1 },
+    "apiVersion": "59.0"
+  },
+  "warnings": []
+}
+```
+
+`path` is `null` on a dry run, and the combined package's path otherwise.
 
 ---
 

--- a/messages/sfpc.combine.md
+++ b/messages/sfpc.combine.md
@@ -12,6 +12,7 @@ Read multiple package.xml files, then parse them and combine them to create 1 fi
 - sf sfpc combine -f pack1.xml -d "test/directory" -c package.xml
 - sf sfpc combine -f packag1.xml -f pack2.xml -v 60.0 -c package.xml
 - sf sfpc combine -f packag1.xml -f pack2.xml -c package.xml -n
+- sf sfpc combine -f pack1.xml -f pack2.xml --dry-run
 
 # flags.package-file.summary
 
@@ -32,3 +33,7 @@ Sets the API version to use in the combined package.xml.
 # flags.no-api-version.summary
 
 Explicitly omit the API version in the combined package.xml.
+
+# flags.dry-run.summary
+
+Preview the combined package summary (types, members, duplicates) without writing an output file.

--- a/src/commands/sfpc/combine.ts
+++ b/src/commands/sfpc/combine.ts
@@ -39,21 +39,60 @@ export default class SfpcCombine extends SfCommand<SfpcCombineResult> {
       char: 'n',
       default: false,
     }),
+    'dry-run': Flags.boolean({
+      summary: messages.getMessage('flags.dry-run.summary'),
+      default: false,
+    }),
   };
 
   public async run(): Promise<SfpcCombineResult> {
     const { flags } = await this.parse(SfpcCombine);
 
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: flags['package-file'],
       combinedPackage: flags['combined-package'],
       directories: flags['directory'],
       userApiVersion: flags['api-version'],
       noApiVersion: flags['no-api-version'],
+      dryRun: flags['dry-run'],
       warn: this.warn.bind(this),
     });
 
-    this.log(`Combined package.xml written to: ${path}`);
-    return { path };
+    this.logSummary(result);
+    return result;
+  }
+
+  private logSummary(result: SfpcCombineResult): void {
+    this.log(`Input files: ${result.filesProcessed}`);
+    this.log('');
+    this.log(`Metadata Types: ${result.types}`);
+    this.log(`Members: ${result.members}`);
+    this.log('');
+    this.log(`Duplicate members removed: ${result.duplicatesRemoved}`);
+    this.log(`API Version: ${result.apiVersion}`);
+
+    if (result.duplicates.length > 0) {
+      this.log('');
+      this.log('Duplicates:');
+      for (const duplicate of result.duplicates) {
+        this.log(`  ${duplicate.type}: ${duplicate.member}`);
+        for (const file of duplicate.files) {
+          this.log(`    ${file}`);
+        }
+      }
+    }
+
+    this.log('');
+    this.log(`${result.dryRun ? 'Output would contain' : 'Output contains'}:`);
+    for (const [type, count] of Object.entries(result.membersByType).sort(([a], [b]) => a.localeCompare(b))) {
+      this.log(`  ${type} ...... ${count}`);
+    }
+
+    this.log('');
+    if (result.dryRun) {
+      this.log('No file written.');
+    } else {
+      this.log(`Combined package.xml written to: ${result.path}`);
+    }
   }
 }

--- a/src/core/combinePackages.ts
+++ b/src/core/combinePackages.ts
@@ -1,5 +1,6 @@
 import { findFilesInDirectory } from '../utils/findFilesinDirectory.js';
 import { mergePackageXmlFiles } from './mergePackageXmlFiles.js';
+import { SfpcCombineResult } from './types.js';
 
 export async function combinePackages({
   packageFiles = [],
@@ -7,6 +8,7 @@ export async function combinePackages({
   directories = [],
   userApiVersion = null,
   noApiVersion = false,
+  dryRun = false,
   warn = (_msg: string): void => {
     /* noop default */
   },
@@ -16,8 +18,9 @@ export async function combinePackages({
   directories?: string[];
   userApiVersion?: string | null;
   noApiVersion?: boolean;
+  dryRun?: boolean;
   warn?: (msg: string) => void;
-}): Promise<string> {
+}): Promise<SfpcCombineResult> {
   const files = [...packageFiles];
   const warnings: string[] = [];
 
@@ -28,9 +31,20 @@ export async function combinePackages({
     warnings.push(...dirWarnings);
   }
 
-  const result = await mergePackageXmlFiles(files, combinedPackage, userApiVersion, noApiVersion);
-  warnings.push(...result);
+  const result = await mergePackageXmlFiles(files, combinedPackage, userApiVersion, noApiVersion, dryRun);
+  warnings.push(...result.warnings);
 
   warnings.forEach(warn);
-  return combinedPackage;
+
+  return {
+    path: dryRun ? null : combinedPackage,
+    dryRun,
+    filesProcessed: files.length,
+    types: result.types,
+    members: result.members,
+    duplicatesRemoved: result.duplicatesRemoved,
+    duplicates: result.duplicates,
+    membersByType: result.membersByType,
+    apiVersion: result.apiVersion,
+  };
 }

--- a/src/core/mergePackageXmlFiles.ts
+++ b/src/core/mergePackageXmlFiles.ts
@@ -3,6 +3,7 @@ import { sfXmlns } from '../utils/constants.js';
 import { getConcurrencyThreshold } from '../utils/getConcurrencyThreshold.js';
 import { mapLimit } from '../utils/mapLimit.js';
 import { determineApiVersion } from './determineApiVersion.js';
+import { MergePackageResult } from './types.js';
 import { writePackage } from './writePackage.js';
 
 export async function mergePackageXmlFiles(
@@ -10,11 +11,13 @@ export async function mergePackageXmlFiles(
   combinedPackage: string,
   userApiVersion: string | null,
   noApiVersion: boolean,
-): Promise<string[]> {
+  dryRun = false,
+): Promise<MergePackageResult> {
   const warnings: string[] = [];
   const apiVersions: string[] = [];
   const concurrencyLimit = getConcurrencyThreshold();
-  const combinedSet = new ComponentSet();
+  // type -> member -> source files that contained it
+  const origins = new Map<string, Map<string, string[]>>();
 
   if (files) {
     await mapLimit(files, concurrencyLimit, async (filePath: string) => {
@@ -26,7 +29,13 @@ export async function mergePackageXmlFiles(
         }
 
         for (const component of componentSet.toArray()) {
-          combinedSet.add(component);
+          const typeName = component.type.name;
+          const memberName = component.fullName;
+          const members = origins.get(typeName) ?? new Map<string, string[]>();
+          origins.set(typeName, members);
+          const sourceFiles = members.get(memberName) ?? [];
+          members.set(memberName, sourceFiles);
+          sourceFiles.push(filePath);
         }
 
         const version = componentSet.sourceApiVersion;
@@ -41,23 +50,34 @@ export async function mergePackageXmlFiles(
     });
   }
 
-  const metadataTypes = groupComponentsByType(combinedSet.toArray());
-
+  const { duplicates, duplicatesRemoved, membersByType, totalMembers } = summarizeOrigins(origins);
   const version = determineApiVersion(apiVersions, userApiVersion, noApiVersion);
-  const packageContents: PackageManifestObject = {
-    Package: {
-      '@_xmlns': sfXmlns,
-      types: Array.from(metadataTypes.entries())
-        .map(([name, members]) => ({
-          members: Array.from(new Set(members)).sort((a, b) => a.localeCompare(b)),
-          name,
-        }))
-        .sort(sortTypesWithCustomObjectFirst),
-      version,
-    },
+
+  if (!dryRun) {
+    const packageContents: PackageManifestObject = {
+      Package: {
+        '@_xmlns': sfXmlns,
+        types: Array.from(origins.entries())
+          .map(([name, members]) => ({
+            members: Array.from(members.keys()).sort((a, b) => a.localeCompare(b)),
+            name,
+          }))
+          .sort(sortTypesWithCustomObjectFirst),
+        version,
+      },
+    };
+    await writePackage(packageContents, combinedPackage);
+  }
+
+  return {
+    warnings,
+    types: origins.size,
+    members: totalMembers,
+    duplicatesRemoved,
+    duplicates,
+    membersByType,
+    apiVersion: version,
   };
-  await writePackage(packageContents, combinedPackage);
-  return warnings;
 }
 
 export const CUSTOM_OBJECT_TYPE = 'CustomObject';
@@ -68,14 +88,33 @@ export function sortTypesWithCustomObjectFirst(a: { name: string }, b: { name: s
   return a.name.localeCompare(b.name);
 }
 
-function groupComponentsByType(components: ReturnType<ComponentSet['toArray']>): Map<string, string[]> {
-  const map = new Map<string, string[]>();
-  for (const component of components) {
-    const typeName = component.type.name;
-    if (!map.has(typeName)) {
-      map.set(typeName, []);
+function summarizeOrigins(origins: Map<string, Map<string, string[]>>): {
+  duplicates: Array<{ type: string; member: string; files: string[] }>;
+  duplicatesRemoved: number;
+  membersByType: Record<string, number>;
+  totalMembers: number;
+} {
+  const duplicates: Array<{ type: string; member: string; files: string[] }> = [];
+  const membersByType: Record<string, number> = {};
+  let duplicatesRemoved = 0;
+  let totalMembers = 0;
+
+  for (const [typeName, members] of origins.entries()) {
+    membersByType[typeName] = members.size;
+    totalMembers += members.size;
+    for (const [memberName, sourceFiles] of members.entries()) {
+      if (sourceFiles.length > 1) {
+        duplicatesRemoved += sourceFiles.length - 1;
+        duplicates.push({
+          type: typeName,
+          member: memberName,
+          files: [...sourceFiles].sort((a, b) => a.localeCompare(b)),
+        });
+      }
     }
-    map.get(typeName)!.push(component.fullName);
   }
-  return map;
+
+  duplicates.sort((a, b) => a.type.localeCompare(b.type) || a.member.localeCompare(b.member));
+
+  return { duplicates, duplicatesRemoved, membersByType, totalMembers };
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,3 +1,27 @@
+export type DuplicateMember = {
+  type: string;
+  member: string;
+  files: string[];
+};
+
+export type MergePackageResult = {
+  warnings: string[];
+  types: number;
+  members: number;
+  duplicatesRemoved: number;
+  duplicates: DuplicateMember[];
+  membersByType: Record<string, number>;
+  apiVersion: string;
+};
+
 export type SfpcCombineResult = {
-  path: string;
+  path: string | null;
+  dryRun: boolean;
+  filesProcessed: number;
+  types: number;
+  members: number;
+  duplicatesRemoved: number;
+  duplicates: DuplicateMember[];
+  membersByType: Record<string, number>;
+  apiVersion: string;
 };

--- a/stryker.config.json
+++ b/stryker.config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/@stryker-mutator/core/schema/stryker-schema.json",
   "packageManager": "npm",
+  "inPlace": true,
   "testRunner": "vitest",
   "vitest": {
     "configFile": "vitest.config.ts",
@@ -15,7 +16,13 @@
     "!src/core/types.ts",
     "!src/utils/constants.ts"
   ],
-  "reporters": ["html", "json", "clear-text", "progress", "dashboard"],
+  "reporters": [
+    "html",
+    "json",
+    "clear-text",
+    "progress",
+    "dashboard"
+  ],
   "htmlReporter": {
     "fileName": "reports/mutation/index.html"
   },
@@ -41,5 +48,11 @@
   "logLevel": "info",
   "fileLogLevel": "trace",
   "checkers": [],
-  "ignorePatterns": ["lib", "coverage", "test/**/*.nut.ts", ".stryker-tmp", "reports"]
+  "ignorePatterns": [
+    "lib",
+    "coverage",
+    "test/**/*.nut.ts",
+    ".stryker-tmp",
+    "reports"
+  ]
 }

--- a/test/commands/sfpc/combine.nut.ts
+++ b/test/commands/sfpc/combine.nut.ts
@@ -1,8 +1,11 @@
 import { strictEqual } from 'node:assert';
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { execCmd, TestSession } from '@salesforce/cli-plugins-testkit';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SfpcCombineResult } from '../../../src/core/types.js';
 
 describe('sfpc combine NUTs', () => {
   let session: TestSession;
@@ -11,6 +14,7 @@ describe('sfpc combine NUTs', () => {
   const package3 = resolve('test/samples/package-custom-label.xml');
   const outputPackage = resolve('package.xml');
   const baseline = resolve('test/samples/expected-combined.xml');
+  const dryRunOutputPackage = resolve('dry-run-nut-output.xml');
 
   beforeAll(async () => {
     session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
@@ -29,5 +33,23 @@ describe('sfpc combine NUTs', () => {
     const testPackage = await readFile(outputPackage, 'utf-8');
     const baselinePackage = await readFile(baseline, 'utf-8');
     strictEqual(testPackage, baselinePackage, `File content is different between ${outputPackage} and ${baseline}`);
+  });
+
+  it('dry-run reports the summary and writes no file.', () => {
+    const command = `sfpc combine -f ${package1} -f ${package2} -f ${package3} -c ${dryRunOutputPackage} --dry-run`;
+    const output = execCmd(command, { ensureExitCode: 0 }).shellOutput.stdout;
+    expect(output).toContain('No file written.');
+    expect(output).toContain('Duplicates:');
+    expect(existsSync(dryRunOutputPackage)).toBe(false);
+  });
+
+  it('dry-run with --json returns the enriched result and a null path.', () => {
+    const command = `sfpc combine -f ${package1} -f ${package2} -f ${package3} -c ${dryRunOutputPackage} --dry-run --json`;
+    const jsonOutput = execCmd<SfpcCombineResult>(command, { ensureExitCode: 0 }).jsonOutput;
+    expect(jsonOutput?.result.path).toBeNull();
+    expect(jsonOutput?.result.dryRun).toBe(true);
+    expect(jsonOutput?.result.filesProcessed).toBe(3);
+    expect(jsonOutput?.result.duplicatesRemoved).toBe(1);
+    expect(existsSync(dryRunOutputPackage)).toBe(false);
   });
 });

--- a/test/commands/sfpc/combine.test.ts
+++ b/test/commands/sfpc/combine.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import { readFile } from 'node:fs/promises';
+import { readFile, unlink } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
 import { describe, expect, it, vi } from 'vitest';
@@ -217,6 +217,13 @@ describe('sfpc combine', () => {
     expect(result.warnings).toEqual([]);
     expect(result.types).toBe(0);
     expect(result.members).toBe(0);
+  });
+
+  it('writes a file when dryRun is omitted (defaults to false)', async () => {
+    const defaultDryRunOutput = resolve('default-dry-run-output.xml');
+    await mergePackageXmlFiles([package1], defaultDryRunOutput, null, false);
+    expect(existsSync(defaultDryRunOutput)).toBe(true);
+    await unlink(defaultDryRunOutput);
   });
 
   it('formats non-Error thrown values using String(err) in warning message', async () => {

--- a/test/commands/sfpc/combine.test.ts
+++ b/test/commands/sfpc/combine.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { ComponentSet } from '@salesforce/source-deploy-retrieve';
@@ -27,13 +28,13 @@ describe('sfpc combine', () => {
 
   it('combines valid packages together', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: [package1, package2, package3],
       combinedPackage: outputPackage,
       warn: (msg) => warnings.push(msg),
     });
 
-    expect(path).toBe(outputPackage);
+    expect(result.path).toBe(outputPackage);
     expect(warnings).toHaveLength(0);
     const content = await readFile(outputPackage, 'utf-8');
     const baselineContent = await readFile(baseline, 'utf-8');
@@ -50,14 +51,14 @@ describe('sfpc combine', () => {
   invalids.forEach((invalidFile, index) => {
     it(`handles invalid package ${index + 1}`, async () => {
       const warnings: string[] = [];
-      const path = await combinePackages({
+      const result = await combinePackages({
         packageFiles: [invalidFile],
         directories: [invalidDir],
         combinedPackage: outputPackage,
         warn: (msg) => warnings.push(msg),
       });
 
-      expect(path).toBe(outputPackage);
+      expect(result.path).toBe(outputPackage);
       expect(warnings.join('\n')).toContain(`Invalid or empty package.xml: ${invalidFile}`);
     });
 
@@ -70,14 +71,14 @@ describe('sfpc combine', () => {
 
   it('combines packages and includes those in a directory', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: [package1, package2, package3],
       directories: [packageDir],
       combinedPackage: outputPackage,
       warn: (msg) => warnings.push(msg),
     });
 
-    expect(path).toBe(outputPackage);
+    expect(result.path).toBe(outputPackage);
     expect(warnings.join('\n')).toContain(`Invalid or empty package.xml: ${invalidDirPackage}`);
   });
 
@@ -89,12 +90,12 @@ describe('sfpc combine', () => {
 
   it('uses default output path when combinedPackage is not specified', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: [package1],
       warn: (msg) => warnings.push(msg),
     });
 
-    expect(path).toBe('package.xml');
+    expect(result.path).toBe('package.xml');
   });
   it('uses default warn function when none is provided', async () => {
     await expect(
@@ -102,30 +103,30 @@ describe('sfpc combine', () => {
         packageFiles: [invalidPackage1],
         combinedPackage: outputPackage,
       }),
-    ).resolves.toBe(outputPackage);
+    ).resolves.toMatchObject({ path: outputPackage });
   });
   it('combines valid packages together at specified API version', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: [package1, package2, package3],
       combinedPackage: outputPackage,
       warn: (msg) => warnings.push(msg),
       userApiVersion: '60.0',
     });
 
-    expect(path).toBe(outputPackage);
+    expect(result.path).toBe(outputPackage);
     expect(warnings).toHaveLength(0);
   });
   it('combines valid packages together omitting the API version', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       packageFiles: [package1, package2, package3],
       combinedPackage: outputPackage,
       warn: (msg) => warnings.push(msg),
       noApiVersion: true,
     });
 
-    expect(path).toBe(outputPackage);
+    expect(result.path).toBe(outputPackage);
     expect(warnings).toHaveLength(0);
     const content = await readFile(outputPackage, 'utf-8');
     expect(content).not.toContain('<version>');
@@ -201,26 +202,28 @@ describe('sfpc combine', () => {
 
   it('uses default packageFiles when none provided and only emits expected warnings', async () => {
     const warnings: string[] = [];
-    const path = await combinePackages({
+    const result = await combinePackages({
       directories: [packageDir],
       combinedPackage: outputPackage,
       warn: (msg) => warnings.push(msg),
     });
-    expect(path).toBe(outputPackage);
+    expect(result.path).toBe(outputPackage);
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain('Invalid or empty package.xml');
   });
 
   it('returns no warnings when files is null (skips processing)', async () => {
-    const warnings = await mergePackageXmlFiles(null, 'package.xml', null, false);
-    expect(warnings).toEqual([]);
+    const result = await mergePackageXmlFiles(null, 'package.xml', null, false);
+    expect(result.warnings).toEqual([]);
+    expect(result.types).toBe(0);
+    expect(result.members).toBe(0);
   });
 
   it('formats non-Error thrown values using String(err) in warning message', async () => {
     const spy = vi.spyOn(ComponentSet, 'fromManifest').mockRejectedValueOnce('boom-string-error');
     try {
-      const warnings = await mergePackageXmlFiles([invalidPackage1], outputPackage, null, false);
-      expect(warnings.join('\n')).toContain(
+      const result = await mergePackageXmlFiles([invalidPackage1], outputPackage, null, false);
+      expect(result.warnings.join('\n')).toContain(
         `Invalid or empty package.xml: ${invalidPackage1}. [SDR] boom-string-error`,
       );
     } finally {
@@ -235,6 +238,86 @@ describe('sfpc combine', () => {
     const output = await readFile(outputPackage, 'utf-8');
     // CustomLabel comes before StandardValueSet alphabetically when neither is CustomObject
     expect(output.indexOf('CustomLabel')).toBeLessThan(output.indexOf('StandardValueSet'));
+  });
+
+  describe('dry-run and stats', () => {
+    const dryRunOutput = resolve('dry-run-output.xml');
+
+    it('does not write a file when dryRun is true', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1, package2, package3],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      expect(result.dryRun).toBe(true);
+      expect(result.path).toBeNull();
+      expect(existsSync(dryRunOutput)).toBe(false);
+    });
+
+    it('reports file/type/member counts and API version for a dry run', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1, package2, package3],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      expect(result.filesProcessed).toBe(3);
+      expect(result.types).toBe(3); // CustomObject, StandardValueSet, CustomLabel
+      expect(result.members).toBe(4); // Account, Case, Industry, Auto
+      expect(result.apiVersion).toBe('59.0');
+    });
+
+    it('reports membersByType per metadata type', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1, package2],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      expect(result.membersByType).toMatchObject({
+        CustomObject: 2, // Account (deduped) + Case
+        StandardValueSet: 1, // Industry
+      });
+    });
+
+    it('reports duplicate members with their source files, sorted, and counts them', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1, package2, package3, package3],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      // duplicatesRemoved: Account appears in package1+package2 (1 extra),
+      // Auto appears in package3 twice (1 extra) = 2 total
+      expect(result.duplicatesRemoved).toBe(2);
+      expect(result.duplicates).toEqual([
+        { type: 'CustomLabel', member: 'Auto', files: [package3, package3] },
+        { type: CUSTOM_OBJECT_TYPE, member: 'Account', files: [package1, package2].sort() },
+      ]);
+    });
+
+    it('sorts duplicates by member name when two duplicates share the same type', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1, package2, package2],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      const customObjectDuplicates = result.duplicates.filter((d) => d.type === CUSTOM_OBJECT_TYPE);
+      expect(customObjectDuplicates.map((d) => d.member)).toEqual(['Account', 'Case']);
+    });
+
+    it('does not populate duplicates when there are none', async () => {
+      const result = await combinePackages({
+        packageFiles: [package1],
+        combinedPackage: dryRunOutput,
+        dryRun: true,
+      });
+
+      expect(result.duplicates).toEqual([]);
+      expect(result.duplicatesRemoved).toBe(0);
+    });
   });
 
   describe('sortTypesWithCustomObjectFirst', () => {


### PR DESCRIPTION
## Summary
- Add `--dry-run` flag to preview a combine (types/members/duplicates/API version) without writing an output file
- Track cross-file duplicate members and report which source files each conflicting member came from
- Enrich the command's return value (visible via `--json`) with `filesProcessed`, `types`, `members`, `duplicatesRemoved`, `duplicates`, `membersByType`, `apiVersion` for CI logging/dashboards

**Breaking change:** `--json` output shape changes from `{ path }` to the enriched result object above (`path` is `null` on `--dry-run`). No public API changes otherwise — `combinePackages()` is internal.

## Test plan
- [x] `npm run test` (compile + lint + unit) passes, 100% stmt/branch/func/line coverage on touched files
- [x] Manually ran `sf sfpc combine --dry-run` and `--dry-run --json` against sample packages, verified summary output and JSON shape
- [x] Manually ran a non-dry-run combine, confirmed written XML unchanged from prior behavior