### PR TITLE
fix(manifest): omit version instead of writing then stripping 0.0

### DIFF
--- a/src/commands/sfpc/combine.ts
+++ b/src/commands/sfpc/combine.ts
@@ -69,7 +69,7 @@ export default class SfpcCombine extends SfCommand<SfpcCombineResult> {
     this.log(`Members: ${result.members}`);
     this.log('');
     this.log(`Duplicate members removed: ${result.duplicatesRemoved}`);
-    this.log(`API Version: ${result.apiVersion}`);
+    this.log(`API Version: ${result.apiVersion ?? 'none'}`);
 
     if (result.duplicates.length > 0) {
       this.log('');

--- a/src/core/determineApiVersion.ts
+++ b/src/core/determineApiVersion.ts
@@ -2,11 +2,12 @@ export function determineApiVersion(
   apiVersions: string[],
   userApiVersion: string | null,
   noApiVersion: boolean,
-): string {
-  if (noApiVersion) return '0.0';
+): string | undefined {
+  if (noApiVersion) return undefined;
   if (userApiVersion === null) {
+    if (apiVersions.length === 0) return undefined;
     // Stryker disable next-line EqualityOperator -- >= produces the same result; reduce finds same max string regardless of tie-breaking
-    return apiVersions.reduce((max, version) => (version > max ? version : max), '0.0');
+    return apiVersions.reduce((max, version) => (version > max ? version : max));
   }
   return userApiVersion;
 }

--- a/src/core/mergePackageXmlFiles.ts
+++ b/src/core/mergePackageXmlFiles.ts
@@ -65,7 +65,7 @@ export async function mergePackageXmlFiles(
             name,
           }))
           .sort(sortTypesWithCustomObjectFirst),
-        version,
+        ...(version !== undefined ? { version } : {}),
       },
     };
     await writePackage(packageContents, combinedPackage);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -2,7 +2,7 @@ export type PackageManifestObject = {
   Package: {
     '@_xmlns': string;
     types: Array<{ name: string; members: string[] }>;
-    version: string;
+    version?: string;
   };
 };
 
@@ -19,7 +19,7 @@ export type MergePackageResult = {
   duplicatesRemoved: number;
   duplicates: DuplicateMember[];
   membersByType: Record<string, number>;
-  apiVersion: string;
+  apiVersion?: string;
 };
 
 export type SfpcCombineResult = {
@@ -31,5 +31,5 @@ export type SfpcCombineResult = {
   duplicatesRemoved: number;
   duplicates: DuplicateMember[];
   membersByType: Record<string, number>;
-  apiVersion: string;
+  apiVersion?: string;
 };

--- a/src/core/writePackage.ts
+++ b/src/core/writePackage.ts
@@ -6,13 +6,7 @@ import { PackageManifestObject } from './types.js';
 
 export async function writePackage(packageXmlObject: PackageManifestObject, combinedPackage: string): Promise<void> {
   const builder = new XMLBuilder(xmlConf);
-  let xmlContent = builder.build(packageXmlObject);
-
-  // Stryker disable next-line ConditionalExpression,EqualityOperator -- regex targets only '0.0' so if(true) is equivalent
-  if (packageXmlObject.Package.version === '0.0') {
-    // Stryker disable next-line Regex -- mutations are equivalent on actual XML output (leading whitespace + line endings handled correctly)
-    xmlContent = xmlContent.replace(/^\s*<version>0\.0<\/version>\s*\r?\n?/gm, '');
-  }
+  const xmlContent = builder.build(packageXmlObject);
 
   const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>\n';
   await writeFile(combinedPackage, xmlHeader + xmlContent);

--- a/test/core/determineApiVersion.test.ts
+++ b/test/core/determineApiVersion.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from 'vitest';
 import { determineApiVersion } from '../../src/core/determineApiVersion.js';
 
 describe('determineApiVersion', () => {
-  it('returns 0.0 when noApiVersion is true', () => {
-    expect(determineApiVersion(['61.0'], null, true)).toBe('0.0');
+  it('returns undefined when noApiVersion is true', () => {
+    expect(determineApiVersion(['61.0'], null, true)).toBeUndefined();
   });
 
   it('noApiVersion takes priority over userApiVersion', () => {
-    expect(determineApiVersion([], '60.0', true)).toBe('0.0');
+    expect(determineApiVersion([], '60.0', true)).toBeUndefined();
   });
 
   it('returns userApiVersion when provided (not null)', () => {
@@ -18,8 +18,8 @@ describe('determineApiVersion', () => {
     expect(determineApiVersion(['59.0', '61.0', '60.0'], null, false)).toBe('61.0');
   });
 
-  it('returns initial 0.0 when apiVersions is empty and userApiVersion is null', () => {
-    expect(determineApiVersion([], null, false)).toBe('0.0');
+  it('returns undefined when apiVersions is empty and userApiVersion is null', () => {
+    expect(determineApiVersion([], null, false)).toBeUndefined();
   });
 
   it('returns the single version in the array', () => {

--- a/test/core/mergePackageXmlFiles.test.ts
+++ b/test/core/mergePackageXmlFiles.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { PackageManifestObject } from '../../src/core/types.js';
+
+const writePackageMock = vi.fn<(pkg: PackageManifestObject, combinedPackage: string) => Promise<void>>(async () => {
+  /* noop */
+});
+
+vi.mock('../../src/core/writePackage.js', () => ({
+  writePackage: (pkg: PackageManifestObject, combinedPackage: string) => writePackageMock(pkg, combinedPackage),
+}));
+
+const { mergePackageXmlFiles } = await import('../../src/core/mergePackageXmlFiles.js');
+
+describe('mergePackageXmlFiles version key', () => {
+  it('omits the version key entirely when noApiVersion is true', async () => {
+    await mergePackageXmlFiles(null, 'package.xml', null, true);
+
+    const [packageContents] = writePackageMock.mock.calls.at(-1)!;
+    expect('version' in packageContents.Package).toBe(false);
+  });
+
+  it('includes the version key when userApiVersion is provided', async () => {
+    await mergePackageXmlFiles(null, 'package.xml', '61.0', false);
+
+    const [packageContents] = writePackageMock.mock.calls.at(-1)!;
+    expect(packageContents.Package.version).toBe('61.0');
+  });
+});

--- a/test/core/writePackage.test.ts
+++ b/test/core/writePackage.test.ts
@@ -9,11 +9,11 @@ import { sfXmlns } from '../../src/utils/constants.js';
 describe('writePackage', () => {
   const outputPath = resolve('package.xml');
 
-  const makePackage = (version: string): PackageManifestObject => ({
+  const makePackage = (version?: string): PackageManifestObject => ({
     Package: {
       '@_xmlns': sfXmlns,
       types: [],
-      version,
+      ...(version !== undefined ? { version } : {}),
     },
   });
 
@@ -29,27 +29,16 @@ describe('writePackage', () => {
     expect(content).toContain('<version>59.0</version>');
   });
 
-  it('removes version element entirely when version is 0.0', async () => {
-    await writePackage(makePackage('0.0'), outputPath);
+  it('omits version element entirely when version is undefined', async () => {
+    await writePackage(makePackage(undefined), outputPath);
     const content = await readFile(outputPath, 'utf-8');
     expect(content).not.toContain('<version>');
-    expect(content).not.toContain('0.0');
-    // Verify replacement is empty string, not a substituted value
-    const unexpectedLines = content.split(/\r?\n/).filter((l) => l.trim() && !l.trim().startsWith('<'));
-    expect(unexpectedLines).toHaveLength(0);
   });
 
-  it('does not corrupt content when stripping 0.0 version', async () => {
-    await writePackage(makePackage('0.0'), outputPath);
+  it('does not corrupt content when version is omitted', async () => {
+    await writePackage(makePackage(undefined), outputPath);
     const content = await readFile(outputPath, 'utf-8');
     expect(content).toContain('<Package');
     expect(content).toContain('</Package>');
-  });
-
-  it('does not strip version when version is not 0.0', async () => {
-    await writePackage(makePackage('61.0'), outputPath);
-    const content = await readFile(outputPath, 'utf-8');
-    expect(content).not.toContain('<version>0.0</version>');
-    expect(content).toContain('<version>61.0</version>');
   });
 });

--- a/test/samples/package-empty.xml
+++ b/test/samples/package-empty.xml
@@ -1,3 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Package xmlns="http://soap.sforce.com/2006/04/metadata">
-</Package>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata"></Package>


### PR DESCRIPTION
## Summary
- `version` is now `string | undefined` end-to-end (`determineApiVersion`, `PackageManifestObject`, `MergePackageResult`, `SfpcCombineResult`) instead of always `string` with `'0.0'` as a sentinel for "no version".
- `writePackage` no longer builds a `<version>0.0</version>` element and regex-strips it afterward — the `version` key is simply omitted from the built object when there's nothing to write.
- CLI summary prints `API Version: none` instead of `API Version: 0.0` when no version applies.

## Test plan
- [x] `npx vitest run` — 79 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] Updated `test/core/determineApiVersion.test.ts` and `test/core/writePackage.test.ts` for the new `undefined`-based behavior
- [x] Regenerated `test/samples/package-empty.xml` baseline to match the new self-closing empty `<Package>` output