### PR TITLE
fix(merge): normalize metadata type names case-insensitively

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ node_modules
 .idea
 
 package.xml
+write-package-test-output.xml
 
 # stryker mutation testing
 .stryker-tmp

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ sf sfpc combine -f package1.xml -f package2.xml --json
 
 ## How it works
 
-- **Metadata types** — `<name>` values are taken as-is and deduplicated by exact, case-sensitive match. They are **not** validated or normalized against Salesforce's metadata registry — see [Invalid Manifests](#invalid-manifests).
-- **Type order** — `CustomObject` is always listed before all other types; remaining types sort alphabetically. This avoids deployment failures when `CustomObject` and its children appear in the same manifest (see [scolladon/sfdx-git-delta#76](https://github.com/scolladon/sfdx-git-delta/pull/76)).
+- **Metadata types** — `<name>` values are deduplicated case-insensitively (`CustomObject` and `customobject` merge into one `<types>` block, using the casing first encountered). They are **not** validated or normalized against Salesforce's metadata registry — see [Invalid Manifests](#invalid-manifests).
+- **Type order** — `CustomObject` (any casing) is always listed before all other types; remaining types sort alphabetically. This avoids deployment failures when `CustomObject` and its children appear in the same manifest (see [scolladon/sfdx-git-delta#76](https://github.com/scolladon/sfdx-git-delta/pull/76)).
 - **Members** — `<members>` values keep their original case (Salesforce API names are case-sensitive).
 - **API version** — Highest `<version>` from all input manifests is used. Override with `-v`, or omit entirely with `-n`.
 

--- a/src/core/mergePackageXmlFiles.ts
+++ b/src/core/mergePackageXmlFiles.ts
@@ -17,8 +17,10 @@ export async function mergePackageXmlFiles(
   const warnings: string[] = [];
   const apiVersions: string[] = [];
   const concurrencyLimit = getConcurrencyThreshold();
-  // type -> member -> source files that contained it
+  // type name (lowercased) -> member -> source files that contained it
   const origins = new Map<string, Map<string, string[]>>();
+  // type name (lowercased) -> the casing first seen for it, used for output/reporting
+  const canonicalTypeNames = new Map<string, string>();
 
   if (files) {
     await mapLimit(files, concurrencyLimit, async (filePath: string) => {
@@ -31,8 +33,12 @@ export async function mergePackageXmlFiles(
         }
 
         for (const type of manifest.types) {
-          const members = origins.get(type.name) ?? new Map<string, string[]>();
-          origins.set(type.name, members);
+          const typeKey = type.name.toLowerCase();
+          if (!canonicalTypeNames.has(typeKey)) {
+            canonicalTypeNames.set(typeKey, type.name);
+          }
+          const members = origins.get(typeKey) ?? new Map<string, string[]>();
+          origins.set(typeKey, members);
           for (const memberName of type.members) {
             const sourceFiles = members.get(memberName) ?? [];
             members.set(memberName, sourceFiles);
@@ -52,7 +58,7 @@ export async function mergePackageXmlFiles(
     });
   }
 
-  const { duplicates, duplicatesRemoved, membersByType, totalMembers } = summarizeOrigins(origins);
+  const { duplicates, duplicatesRemoved, membersByType, totalMembers } = summarizeOrigins(origins, canonicalTypeNames);
   const version = determineApiVersion(apiVersions, userApiVersion, noApiVersion);
 
   if (!dryRun) {
@@ -60,9 +66,9 @@ export async function mergePackageXmlFiles(
       Package: {
         '@_xmlns': sfXmlns,
         types: Array.from(origins.entries())
-          .map(([name, members]) => ({
+          .map(([typeKey, members]) => ({
             members: Array.from(members.keys()).sort((a, b) => a.localeCompare(b)),
-            name,
+            name: canonicalTypeNames.get(typeKey) ?? typeKey,
           }))
           .sort(sortTypesWithCustomObjectFirst),
         ...(version !== undefined ? { version } : {}),
@@ -85,12 +91,17 @@ export async function mergePackageXmlFiles(
 export const CUSTOM_OBJECT_TYPE = 'CustomObject';
 
 export function sortTypesWithCustomObjectFirst(a: { name: string }, b: { name: string }): number {
-  if (a.name === CUSTOM_OBJECT_TYPE && b.name !== CUSTOM_OBJECT_TYPE) return -1;
-  if (a.name !== CUSTOM_OBJECT_TYPE && b.name === CUSTOM_OBJECT_TYPE) return 1;
+  const aIsCustomObject = a.name.toLowerCase() === CUSTOM_OBJECT_TYPE.toLowerCase();
+  const bIsCustomObject = b.name.toLowerCase() === CUSTOM_OBJECT_TYPE.toLowerCase();
+  if (aIsCustomObject && !bIsCustomObject) return -1;
+  if (!aIsCustomObject && bIsCustomObject) return 1;
   return a.name.localeCompare(b.name);
 }
 
-function summarizeOrigins(origins: Map<string, Map<string, string[]>>): {
+function summarizeOrigins(
+  origins: Map<string, Map<string, string[]>>,
+  canonicalTypeNames: Map<string, string>,
+): {
   duplicates: Array<{ type: string; member: string; files: string[] }>;
   duplicatesRemoved: number;
   membersByType: Record<string, number>;
@@ -101,7 +112,8 @@ function summarizeOrigins(origins: Map<string, Map<string, string[]>>): {
   let duplicatesRemoved = 0;
   let totalMembers = 0;
 
-  for (const [typeName, members] of origins.entries()) {
+  for (const [typeKey, members] of origins.entries()) {
+    const typeName = canonicalTypeNames.get(typeKey) ?? typeKey;
     membersByType[typeName] = members.size;
     totalMembers += members.size;
     for (const [memberName, sourceFiles] of members.entries()) {

--- a/src/core/mergePackageXmlFiles.ts
+++ b/src/core/mergePackageXmlFiles.ts
@@ -33,6 +33,7 @@ export async function mergePackageXmlFiles(
         }
 
         for (const type of manifest.types) {
+          // Stryker disable next-line MethodExpression -- toUpperCase() would group identically; metadata type names are ASCII, so casing of the internal grouping key is unobservable
           const typeKey = type.name.toLowerCase();
           if (!canonicalTypeNames.has(typeKey)) {
             canonicalTypeNames.set(typeKey, type.name);

--- a/test/commands/sfpc/combine.test.ts
+++ b/test/commands/sfpc/combine.test.ts
@@ -100,7 +100,7 @@ describe('sfpc combine', () => {
     expect(content).toContain('<members>Account.Rating__c</members>');
   });
 
-  it('treats metadata type names as case-sensitive literals and does not merge differently-cased types', async () => {
+  it('normalizes metadata type names case-insensitively and merges differently-cased types', async () => {
     const result = await mergePackageXmlFiles(
       [package1, resolve('test/samples/package-lowercase-customobject.xml')],
       outputPackage,
@@ -108,8 +108,12 @@ describe('sfpc combine', () => {
       false,
     );
 
-    expect(result.types).toBe(2);
-    expect(result.membersByType).toMatchObject({ CustomObject: 1, customobject: 1 });
+    expect(result.types).toBe(1);
+    expect(result.membersByType).toMatchObject({ CustomObject: 2 });
+    const content = await readFile(outputPackage, 'utf-8');
+    expect(content).toContain('<name>CustomObject</name>');
+    expect(content).toContain('<members>Account</members>');
+    expect(content).toContain('<members>Lead</members>');
   });
 
   it('combines packages and includes those in a directory', async () => {

--- a/test/core/writePackage.test.ts
+++ b/test/core/writePackage.test.ts
@@ -7,7 +7,7 @@ import { writePackage } from '../../src/core/writePackage.js';
 import { sfXmlns } from '../../src/utils/constants.js';
 
 describe('writePackage', () => {
-  const outputPath = resolve('package.xml');
+  const outputPath = resolve('write-package-test-output.xml');
 
   const makePackage = (version?: string): PackageManifestObject => ({
     Package: {


### PR DESCRIPTION
## Summary
- Group metadata `<types><name>` values case-insensitively when merging package.xml files, so e.g. `CustomObject` and `customobject` from different source files merge into one `<types>` block instead of producing two.
- `sortTypesWithCustomObjectFirst` now matches `CustomObject` case-insensitively so the sort-first pin applies regardless of source casing.
- Canonical output casing is the first casing encountered across input files.

## Why
Salesforce's Metadata API accepts type names in any case, but the combiner was deduplicating/sorting by exact string match, silently producing duplicate `<types>` blocks for the same type when input files used inconsistent casing.

## Test plan
- [x] `npx vitest run` — 81 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] Updated `combine.test.ts` case to assert merge (previously asserted no-merge)