### PR TITLE
fix(merge): pick canonical type casing deterministically

### DIFF
--- a/src/core/mergePackageXmlFiles.ts
+++ b/src/core/mergePackageXmlFiles.ts
@@ -21,42 +21,52 @@ export async function mergePackageXmlFiles(
   const origins = new Map<string, Map<string, string[]>>();
   // type name (lowercased) -> the casing first seen for it, used for output/reporting
   const canonicalTypeNames = new Map<string, string>();
+  // type name (lowercased) -> index (in `files`) that contributed the current canonical casing.
+  // mapLimit processes files concurrently, so completion order doesn't match `files` order --
+  // track the source index explicitly so the canonical casing is deterministic regardless of
+  // which file's read/parse happens to finish first.
+  const canonicalTypeSourceIndex = new Map<string, number>();
 
   if (files) {
-    await mapLimit(files, concurrencyLimit, async (filePath: string) => {
-      try {
-        const xml = await readFile(filePath, 'utf-8');
-        const manifest = parseManifestXml(xml);
-        if (manifest.types.length === 0) {
-          warnings.push(`Invalid or empty package.xml: ${filePath}`);
-          return;
-        }
-
-        for (const type of manifest.types) {
-          // Stryker disable next-line MethodExpression -- toUpperCase() would group identically; metadata type names are ASCII, so casing of the internal grouping key is unobservable
-          const typeKey = type.name.toLowerCase();
-          if (!canonicalTypeNames.has(typeKey)) {
-            canonicalTypeNames.set(typeKey, type.name);
+    await mapLimit(
+      files.map((filePath, index) => ({ filePath, index })),
+      concurrencyLimit,
+      async ({ filePath, index }) => {
+        try {
+          const xml = await readFile(filePath, 'utf-8');
+          const manifest = parseManifestXml(xml);
+          if (manifest.types.length === 0) {
+            warnings.push(`Invalid or empty package.xml: ${filePath}`);
+            return;
           }
-          const members = origins.get(typeKey) ?? new Map<string, string[]>();
-          origins.set(typeKey, members);
-          for (const memberName of type.members) {
-            const sourceFiles = members.get(memberName) ?? [];
-            members.set(memberName, sourceFiles);
-            sourceFiles.push(filePath);
-          }
-        }
 
-        const version = manifest.version;
-        // Stryker disable next-line ConditionalExpression,LogicalOperator -- null/undefined version doesn't affect max computation in determineApiVersion
-        if (version && !apiVersions.includes(version)) {
-          apiVersions.push(version);
+          for (const type of manifest.types) {
+            // Stryker disable next-line MethodExpression -- toUpperCase() would group identically; metadata type names are ASCII, so casing of the internal grouping key is unobservable
+            const typeKey = type.name.toLowerCase();
+            if (isEarlierSource(index, canonicalTypeSourceIndex.get(typeKey))) {
+              canonicalTypeNames.set(typeKey, type.name);
+              canonicalTypeSourceIndex.set(typeKey, index);
+            }
+            const members = origins.get(typeKey) ?? new Map<string, string[]>();
+            origins.set(typeKey, members);
+            for (const memberName of type.members) {
+              const sourceFiles = members.get(memberName) ?? [];
+              members.set(memberName, sourceFiles);
+              sourceFiles.push(filePath);
+            }
+          }
+
+          const version = manifest.version;
+          // Stryker disable next-line ConditionalExpression,LogicalOperator -- null/undefined version doesn't affect max computation in determineApiVersion
+          if (version && !apiVersions.includes(version)) {
+            apiVersions.push(version);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          warnings.push(`Invalid or empty package.xml: ${filePath}. ${message}`);
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        warnings.push(`Invalid or empty package.xml: ${filePath}. ${message}`);
-      }
-    });
+      },
+    );
   }
 
   const { duplicates, duplicatesRemoved, membersByType, totalMembers } = summarizeOrigins(origins, canonicalTypeNames);
@@ -87,6 +97,15 @@ export async function mergePackageXmlFiles(
     membersByType,
     apiVersion: version,
   };
+}
+
+/**
+ * Whether a type name's source file index should replace the current canonical casing.
+ * Exported so it's directly unit-testable -- `mapLimit` processes files concurrently, so
+ * exercising this via the real merge would depend on nondeterministic completion timing.
+ */
+export function isEarlierSource(candidateIndex: number, existingIndex: number | undefined): boolean {
+  return existingIndex === undefined || candidateIndex < existingIndex;
 }
 
 export const CUSTOM_OBJECT_TYPE = 'CustomObject';

--- a/test/core/mergePackageXmlFiles.test.ts
+++ b/test/core/mergePackageXmlFiles.test.ts
@@ -10,7 +10,25 @@ vi.mock('../../src/core/writePackage.js', () => ({
   writePackage: (pkg: PackageManifestObject, combinedPackage: string) => writePackageMock(pkg, combinedPackage),
 }));
 
-const { mergePackageXmlFiles } = await import('../../src/core/mergePackageXmlFiles.js');
+const { mergePackageXmlFiles, isEarlierSource } = await import('../../src/core/mergePackageXmlFiles.js');
+
+describe('isEarlierSource', () => {
+  it('returns true when there is no existing source index', () => {
+    expect(isEarlierSource(3, undefined)).toBe(true);
+  });
+
+  it('returns true when the candidate index is earlier than the existing one', () => {
+    expect(isEarlierSource(1, 2)).toBe(true);
+  });
+
+  it('returns false when the candidate index is later than the existing one', () => {
+    expect(isEarlierSource(2, 1)).toBe(false);
+  });
+
+  it('returns false when the candidate index equals the existing one', () => {
+    expect(isEarlierSource(1, 1)).toBe(false);
+  });
+});
 
 describe('mergePackageXmlFiles version key', () => {
   it('omits the version key entirely when noApiVersion is true', async () => {


### PR DESCRIPTION
## Summary
- Fixes a real intermittent CI failure: https://github.com/mcarvin8/sf-package-combiner/actions/runs/32256276618/job/96078594657 (windows-latest, node 22), root-caused to a race introduced in #201.
- `mergePackageXmlFiles` merges case-insensitively-duplicated metadata types (e.g. `CustomObject` / `customobject`) and picks one casing for the output. That pick was previously "whichever file's async read/parse callback finishes first" — nondeterministic under `mapLimit`'s concurrency, since completion order doesn't have to match `files` array order.
- Now tracks each type's source file index explicitly and only replaces the canonical casing with a candidate from an earlier index, independent of completion order.
- The comparison itself is pulled into an exported `isEarlierSource()` and unit tested directly, rather than relying on real concurrency timing (which is inherently nondeterministic) to exercise both branches.

## Why
Real bug on `main`, not flaky infra — confirmed by re-running the exact failing assertion locally and reproducing the wrong-casing output.

## Test plan
- [x] `npx vitest run` — 85 tests passing
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check src test` — clean
- [x] `npx knip` — clean
- [x] `npx stryker run --mutate "src/core/mergePackageXmlFiles.ts"` — 100% (105/105 killed)
- [x] Stress-ran `combine.test.ts` 15x locally with no casing flake