### PR TITLE
fix(writePackage): replace fast-xml-builder with custom writer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@oclif/core": "4.13.5",
         "@salesforce/core": "9.1.2",
         "@salesforce/sf-plugins-core": "13.0.0",
-        "fast-xml-builder": "1.3.1",
         "txml": "6.0.1"
       },
       "devDependencies": {
@@ -8816,37 +8815,6 @@
         "fast-string-width": "^3.0.2"
       }
     },
-    "node_modules/fast-xml-builder": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
-      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.6.2",
-        "xml-naming": "^0.3.0"
-      }
-    },
-    "node_modules/fast-xml-builder/node_modules/xml-naming": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
-      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -12721,21 +12689,6 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/path-expression-matcher": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
-      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@oclif/core": "4.13.5",
     "@salesforce/core": "9.1.2",
     "@salesforce/sf-plugins-core": "13.0.0",
-    "fast-xml-builder": "1.3.1",
     "txml": "6.0.1"
   },
   "devDependencies": {

--- a/src/core/writePackage.ts
+++ b/src/core/writePackage.ts
@@ -1,12 +1,10 @@
 import { writeFile } from 'node:fs/promises';
-import XMLBuilder from 'fast-xml-builder';
 
-import { xmlConf } from '../utils/constants.js';
+import { buildXml } from '../utils/xmlBuilder.js';
 import { PackageManifestObject } from './types.js';
 
 export async function writePackage(packageXmlObject: PackageManifestObject, combinedPackage: string): Promise<void> {
-  const builder = new XMLBuilder(xmlConf);
-  const xmlContent = builder.build(packageXmlObject);
+  const xmlContent = buildXml(packageXmlObject);
 
   const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>\n';
   await writeFile(combinedPackage, xmlHeader + xmlContent);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,8 +1,1 @@
 export const sfXmlns = 'http://soap.sforce.com/2006/04/metadata';
-export const xmlConf = {
-  format: true,
-  indentBy: '    ',
-  suppressEmptyNode: false,
-  ignoreAttributes: false,
-  attributeNamePrefix: '@_',
-};

--- a/src/utils/xmlBuilder.ts
+++ b/src/utils/xmlBuilder.ts
@@ -1,0 +1,69 @@
+const ATTRIBUTE_PREFIX = '@_';
+const INDENT = '    ';
+
+// Matches fast-xml-builder's default entity order: & must run first so
+// entities it introduces (&lt; etc.) are not themselves re-escaped.
+const escapeXmlValue = (value: string): string =>
+  value
+    .replaceAll('&', '&amp;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('<', '&lt;')
+    .replaceAll("'", '&apos;')
+    .replaceAll('"', '&quot;');
+
+const toText = (value: unknown): string => String(value);
+
+type XmlNode = Record<string, unknown>;
+
+function buildAttributes(node: XmlNode): string {
+  let attrStr = '';
+  for (const key of Object.keys(node)) {
+    if (!key.startsWith(ATTRIBUTE_PREFIX)) continue;
+    const name = key.slice(ATTRIBUTE_PREFIX.length);
+    attrStr += ` ${name}="${escapeXmlValue(toText(node[key]))}"`;
+  }
+  return attrStr;
+}
+
+function buildChildren(node: XmlNode, depth: number): string {
+  let out = '';
+  for (const key of Object.keys(node)) {
+    if (key.startsWith(ATTRIBUTE_PREFIX)) continue;
+    const value = node[key];
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const item of value) out += buildElement(key, item, depth);
+    } else {
+      out += buildElement(key, value, depth);
+    }
+  }
+  return out;
+}
+
+function buildElement(key: string, value: unknown, depth: number): string {
+  const indent = INDENT.repeat(depth);
+  if (value === null) return `${indent}<${key}/>\n`;
+
+  if (typeof value !== 'object') {
+    const text = toText(value);
+    return text === '' ? `${indent}<${key}></${key}>\n` : `${indent}<${key}>${escapeXmlValue(text)}</${key}>\n`;
+  }
+
+  const node = value as XmlNode;
+  const attrStr = buildAttributes(node);
+  const childrenStr = buildChildren(node, depth + 1);
+  return childrenStr === ''
+    ? `${indent}<${key}${attrStr}></${key}>\n`
+    : `${indent}<${key}${attrStr}>\n${childrenStr}${indent}</${key}>\n`;
+}
+
+/**
+ * Minimal replacement for fast-xml-builder, matching its output byte-for-byte
+ * for this project's config (format: true, indentBy: 4 spaces, ignoreAttributes:
+ * false, attributeNamePrefix: '@_', suppressEmptyNode: false). Root object must
+ * have exactly one top-level key.
+ */
+export function buildXml(jObj: XmlNode): string {
+  const [rootKey] = Object.keys(jObj);
+  return buildElement(rootKey, jObj[rootKey], 0);
+}

--- a/src/utils/xmlBuilder.ts
+++ b/src/utils/xmlBuilder.ts
@@ -45,8 +45,7 @@ function buildElement(key: string, value: unknown, depth: number): string {
   if (value === null) return `${indent}<${key}/>\n`;
 
   if (typeof value !== 'object') {
-    const text = toText(value);
-    return text === '' ? `${indent}<${key}></${key}>\n` : `${indent}<${key}>${escapeXmlValue(text)}</${key}>\n`;
+    return `${indent}<${key}>${escapeXmlValue(toText(value))}</${key}>\n`;
   }
 
   const node = value as XmlNode;

--- a/test/utils/xmlBuilder.test.ts
+++ b/test/utils/xmlBuilder.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildXml } from '../../src/utils/xmlBuilder.js';
+
+describe('buildXml', () => {
+  it('renders attributes, repeated array elements, and text nodes', () => {
+    const xml = buildXml({
+      Package: {
+        '@_xmlns': 'http://soap.sforce.com/2006/04/metadata',
+        types: [
+          { name: 'ApexClass', members: ['Foo', 'Bar & Baz', 'A<B'] },
+          { name: 'CustomObject', members: ['Account'] },
+        ],
+        version: '59.0',
+      },
+    });
+
+    expect(xml).toBe(
+      [
+        '<Package xmlns="http://soap.sforce.com/2006/04/metadata">',
+        '    <types>',
+        '        <name>ApexClass</name>',
+        '        <members>Foo</members>',
+        '        <members>Bar &amp; Baz</members>',
+        '        <members>A&lt;B</members>',
+        '    </types>',
+        '    <types>',
+        '        <name>CustomObject</name>',
+        '        <members>Account</members>',
+        '    </types>',
+        '    <version>59.0</version>',
+        '</Package>\n',
+      ].join('\n'),
+    );
+  });
+
+  it('renders empty root as a paired self-closing-free tag when there are no children', () => {
+    const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [] } });
+    expect(xml).toBe('<Package xmlns="ns"></Package>\n');
+  });
+
+  it('omits undefined fields entirely', () => {
+    const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [], version: undefined } });
+    expect(xml).not.toContain('<version>');
+  });
+});

--- a/test/utils/xmlBuilder.test.ts
+++ b/test/utils/xmlBuilder.test.ts
@@ -43,4 +43,20 @@ describe('buildXml', () => {
     const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [], version: undefined } });
     expect(xml).not.toContain('<version>');
   });
+
+  it('escapes >, \', and " in text nodes', () => {
+    const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [], version: `a>b'c"d` } });
+    expect(xml).toContain('<version>a&gt;b&apos;c&quot;d</version>');
+  });
+
+  it('renders a null value as a self-closing tag', () => {
+    const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [], version: null } });
+    expect(xml).toContain('<version/>');
+  });
+
+  it('renders an empty-string text value as a paired tag, not self-closing', () => {
+    const xml = buildXml({ Package: { '@_xmlns': 'ns', types: [], version: '' } });
+    expect(xml).toContain('<version></version>');
+    expect(xml).not.toContain('<version/>');
+  });
 });


### PR DESCRIPTION
## Summary
- Drop the `fast-xml-builder` dependency; `writePackage` now serializes via a small hand-rolled writer scoped to this project's `package.xml` shape (attributes, repeated array elements, text leaves).
- Output verified byte-identical to the previous `fast-xml-builder` config (4-space indent, `@_` attribute prefix, `suppressEmptyNode: false`) for representative inputs, including entity-escaped member names.

## Test plan
- [x] `npm test` (compile, lint, full vitest suite) passes
- [x] `npx knip` clean (no unused deps/exports)
- [x] New unit tests in `test/utils/xmlBuilder.test.ts` cover attrs/arrays/escaping, empty root, and omitted-`version` cases
- [x] Existing `test/core/writePackage.test.ts` (header, version present/omitted) passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)