### PR TITLE
feat(parser): replace txml with an in-house XML parser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
       "dependencies": {
         "@oclif/core": "4.13.5",
         "@salesforce/core": "9.1.2",
-        "@salesforce/sf-plugins-core": "13.0.0",
-        "txml": "6.0.1"
+        "@salesforce/sf-plugins-core": "13.0.0"
       },
       "devDependencies": {
         "@biomejs/biome": "2.5.9",
@@ -14816,15 +14815,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/txml": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-6.0.1.tgz",
-      "integrity": "sha512-NdzaukxAFKttLElFcQevCFSGCvSyXViyX8s5zm1JP5XV/B/pX7GatMpRb+z4s9e8fKT/q2qIK8BrnBAoO2rhBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/type-detect": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "dependencies": {
     "@oclif/core": "4.13.5",
     "@salesforce/core": "9.1.2",
-    "@salesforce/sf-plugins-core": "13.0.0",
-    "txml": "6.0.1"
+    "@salesforce/sf-plugins-core": "13.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.9",

--- a/src/core/parseManifest.ts
+++ b/src/core/parseManifest.ts
@@ -1,4 +1,4 @@
-import { parse, TNode } from 'txml';
+import { parseXml, XmlNode } from './xmlParser.js';
 
 export type ParsedManifestType = {
   name: string;
@@ -10,18 +10,18 @@ export type ParsedManifest = {
   version: string | null;
 };
 
-function isElement(node: TNode | string): node is TNode {
+function isElement(node: XmlNode | string): node is XmlNode {
   return typeof node !== 'string';
 }
 
-function getText(node: TNode): string {
+function getText(node: XmlNode): string {
   return node.children
     .filter((child): child is string => typeof child === 'string')
     .join('')
     .trim();
 }
 
-function parseTypesElement(typesEl: TNode): ParsedManifestType {
+function parseTypesElement(typesEl: XmlNode): ParsedManifestType {
   const children = typesEl.children.filter(isElement);
   const nameEls = children.filter((el) => el.tagName === 'name');
   const memberEls = children.filter((el) => el.tagName === 'members');
@@ -60,7 +60,7 @@ function parseTypesElement(typesEl: TNode): ParsedManifestType {
  * type names are not checked against the Salesforce metadata registry.
  */
 export function parseManifestXml(xml: string): ParsedManifest {
-  const roots = parse(xml, { decodeEntities: true, skipXmlDeclaration: true }).filter(isElement);
+  const roots = parseXml(xml);
 
   if (roots.length !== 1 || roots[0].tagName !== 'Package') {
     throw new Error('manifest must have a single <Package> root element');

--- a/src/core/xmlParser.ts
+++ b/src/core/xmlParser.ts
@@ -31,11 +31,13 @@ export function parseXml(xml: string): XmlNode[] {
   let i = 0;
 
   function skipWhitespace(): void {
+    // Stryker disable next-line ConditionalExpression,EqualityOperator -- at i===length, xml[i] is undefined and /\s/.test(undefined) is false, so the loop always stops there regardless of the bound check
     while (i < length && /\s/.test(xml[i])) i++;
   }
 
   function parseName(): string {
     const start = i;
+    // Stryker disable next-line EqualityOperator -- an off-by-one bound (i<=length) only lets the loop run one extra step to length+1; xml.slice clamps beyond the string end and every later bound check uses >=, so the extra step is unobservable
     while (i < length && !/[\s/>]/.test(xml[i])) i++;
     if (i === start) {
       throw new Error(`expected element name at position ${i}`);
@@ -52,6 +54,7 @@ export function parseXml(xml: string): XmlNode[] {
       const ch = xml[i];
       if (ch === '>' || ch === '/') return;
 
+      // Stryker disable next-line EqualityOperator -- same off-by-one equivalence as parseName's loop: the extra step to length+1 is unobservable
       while (i < length && !/[\s=/>]/.test(xml[i])) i++;
       skipWhitespace();
       if (xml[i] !== '=') {
@@ -133,6 +136,7 @@ export function parseXml(xml: string): XmlNode[] {
   }
 
   const roots: XmlNode[] = [];
+  // Stryker disable next-line EqualityOperator -- an off-by-one bound (i<=length) just defers the loop exit from the while-condition to the `i >= length` break on the next iteration; the outcome is identical
   while (i < length) {
     skipWhitespace();
     if (i >= length) break;

--- a/src/core/xmlParser.ts
+++ b/src/core/xmlParser.ts
@@ -1,0 +1,153 @@
+export type XmlNode = {
+  tagName: string;
+  children: Array<XmlNode | string>;
+};
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+};
+
+function decodeEntities(text: string): string {
+  return text.replace(/&(#x[0-9a-fA-F]+|#\d+|[a-zA-Z]+);/g, (match, entity: string) => {
+    if (entity.startsWith('#')) {
+      const codePoint = entity[1] === 'x' ? Number.parseInt(entity.slice(2), 16) : Number.parseInt(entity.slice(1), 10);
+      return String.fromCodePoint(codePoint);
+    }
+    return NAMED_ENTITIES[entity] ?? match;
+  });
+}
+
+/**
+ * Minimal recursive-descent XML parser scoped to Salesforce package.xml manifests:
+ * elements, attributes (skipped -- unused by callers), text, entities, comments,
+ * and the leading <?xml ?> declaration. No DTD/CDATA support since manifests don't use them.
+ */
+export function parseXml(xml: string): XmlNode[] {
+  const length = xml.length;
+  let i = 0;
+
+  function skipWhitespace(): void {
+    while (i < length && /\s/.test(xml[i])) i++;
+  }
+
+  function parseName(): string {
+    const start = i;
+    while (i < length && !/[\s/>]/.test(xml[i])) i++;
+    if (i === start) {
+      throw new Error(`expected element name at position ${i}`);
+    }
+    return xml.slice(start, i);
+  }
+
+  function skipAttributes(): void {
+    while (true) {
+      skipWhitespace();
+      if (i >= length) {
+        throw new Error('unexpected end of input inside a tag');
+      }
+      const ch = xml[i];
+      if (ch === '>' || ch === '/') return;
+
+      while (i < length && !/[\s=/>]/.test(xml[i])) i++;
+      skipWhitespace();
+      if (xml[i] !== '=') {
+        throw new Error(`expected "=" in attribute at position ${i}`);
+      }
+      i++;
+      skipWhitespace();
+      const quote = xml[i];
+      if (quote !== '"' && quote !== "'") {
+        throw new Error(`expected quoted attribute value at position ${i}`);
+      }
+      i++;
+      const end = xml.indexOf(quote, i);
+      if (end === -1) {
+        throw new Error('unterminated attribute value');
+      }
+      i = end + 1;
+    }
+  }
+
+  function skipComment(): void {
+    const end = xml.indexOf('-->', i + 4);
+    if (end === -1) {
+      throw new Error('unterminated comment');
+    }
+    i = end + 3;
+  }
+
+  function skipDeclaration(): void {
+    const end = xml.indexOf('?>', i + 2);
+    if (end === -1) {
+      throw new Error('unterminated processing instruction');
+    }
+    i = end + 2;
+  }
+
+  function parseElement(): XmlNode {
+    i++; // consume '<'
+    const tagName = parseName();
+    skipAttributes();
+
+    if (xml[i] === '/') {
+      i += 2; // consume '/>'
+      return { tagName, children: [] };
+    }
+    i++; // consume '>'
+
+    const children: Array<XmlNode | string> = [];
+    while (true) {
+      if (i >= length) {
+        throw new Error(`unterminated element <${tagName}>`);
+      }
+      if (xml.startsWith('<!--', i)) {
+        skipComment();
+        continue;
+      }
+      if (xml.startsWith('</', i)) {
+        const closeEnd = xml.indexOf('>', i + 2);
+        if (closeEnd === -1) {
+          throw new Error(`unterminated closing tag for <${tagName}>`);
+        }
+        const closeName = xml.slice(i + 2, closeEnd).trim();
+        if (closeName !== tagName) {
+          throw new Error(`mismatched closing tag </${closeName}> for <${tagName}>`);
+        }
+        i = closeEnd + 1;
+        return { tagName, children };
+      }
+      if (xml[i] === '<') {
+        children.push(parseElement());
+        continue;
+      }
+
+      const nextTag = xml.indexOf('<', i);
+      const textEnd = nextTag === -1 ? length : nextTag;
+      children.push(decodeEntities(xml.slice(i, textEnd)));
+      i = textEnd;
+    }
+  }
+
+  const roots: XmlNode[] = [];
+  while (i < length) {
+    skipWhitespace();
+    if (i >= length) break;
+    if (xml.startsWith('<!--', i)) {
+      skipComment();
+      continue;
+    }
+    if (xml.startsWith('<?', i)) {
+      skipDeclaration();
+      continue;
+    }
+    if (xml[i] !== '<') {
+      throw new Error(`unexpected content outside the root element at position ${i}`);
+    }
+    roots.push(parseElement());
+  }
+  return roots;
+}

--- a/test/commands/sfpc/combine.test.ts
+++ b/test/commands/sfpc/combine.test.ts
@@ -280,6 +280,16 @@ describe('sfpc combine', () => {
     expect(result.warnings.join('\n')).toContain(`Invalid or empty package.xml: ${invalidPackage1}. boom-string-error`);
   });
 
+  it('round-trips XML entities and dot-notation custom field members', async () => {
+    const specialCharsPackage = resolve('test/samples/package-special-chars.xml');
+    await mergePackageXmlFiles([specialCharsPackage], outputPackage, null, false);
+
+    const output = await readFile(outputPackage, 'utf-8');
+    expect(output).toContain('<members>Account.Rating__c</members>');
+    expect(output).toContain('<members>Account.Sales_Region__c</members>');
+    expect(output).toContain('<members>Sales &amp; Marketing</members>');
+  });
+
   it('sorts non-CustomObject types alphabetically (branch coverage for sortTypesWithCustomObjectFirst)', async () => {
     const packageNonObjectTypes = resolve('test/samples/package-non-object-types.xml');
     await mergePackageXmlFiles([packageNonObjectTypes], outputPackage, null, false);

--- a/test/core/parseManifest.test.ts
+++ b/test/core/parseManifest.test.ts
@@ -102,6 +102,28 @@ describe('parseManifestXml', () => {
     expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A & B'] }]);
   });
 
+  it('trims leading and trailing whitespace inside a text element', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A</members>
+    <name>  ApexClass  </name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A'] }]);
+  });
+
+  it('joins text split across a nested element and ignores that element (getText)', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>A</members>
+    <name>Apex<x/>Class</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A'] }]);
+  });
+
   it('parses dot-notation custom field members and decodes ampersands', () => {
     const xml = `<Package xmlns="${xmlns}">
   <types>

--- a/test/core/parseManifest.test.ts
+++ b/test/core/parseManifest.test.ts
@@ -102,6 +102,25 @@ describe('parseManifestXml', () => {
     expect(parseManifestXml(xml).types).toEqual([{ name: 'ApexClass', members: ['A & B'] }]);
   });
 
+  it('parses dot-notation custom field members and decodes ampersands', () => {
+    const xml = `<Package xmlns="${xmlns}">
+  <types>
+    <members>Account.Rating__c</members>
+    <members>Account.Sales_Region__c</members>
+    <name>CustomField</name>
+  </types>
+  <types>
+    <members>Sales &amp; Marketing</members>
+    <name>Group</name>
+  </types>
+</Package>`;
+
+    expect(parseManifestXml(xml).types).toEqual([
+      { name: 'CustomField', members: ['Account.Rating__c', 'Account.Sales_Region__c'] },
+      { name: 'Group', members: ['Sales & Marketing'] },
+    ]);
+  });
+
   it('throws when the root element is not <Package>', () => {
     const xml = `<NotAPackage></NotAPackage>`;
     expect(() => parseManifestXml(xml)).toThrow(/single <Package> root element/);

--- a/test/core/xmlParser.test.ts
+++ b/test/core/xmlParser.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseXml } from '../../src/core/xmlParser.js';
+
+describe('parseXml', () => {
+  it('parses a simple element with text content', () => {
+    const roots = parseXml('<Package><version>60.0</version></Package>');
+    expect(roots).toEqual([
+      {
+        tagName: 'Package',
+        children: [{ tagName: 'version', children: ['60.0'] }],
+      },
+    ]);
+  });
+
+  it('skips the leading xml declaration', () => {
+    const roots = parseXml('<?xml version="1.0" encoding="UTF-8"?>\n<Package></Package>');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('skips attributes, including namespaces', () => {
+    const roots = parseXml('<Package xmlns="http://soap.sforce.com/2006/04/metadata"></Package>');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('skips a comment before the root element', () => {
+    const roots = parseXml('<!-- leading comment --><Package></Package>');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('skips comments', () => {
+    const roots = parseXml('<Package><!-- a comment --><version>60.0</version></Package>');
+    expect(roots).toEqual([
+      {
+        tagName: 'Package',
+        children: [{ tagName: 'version', children: ['60.0'] }],
+      },
+    ]);
+  });
+
+  it('decodes named and numeric entities in text', () => {
+    const roots = parseXml('<members>A &amp; B &#65; &#x42;</members>');
+    expect(roots).toEqual([{ tagName: 'members', children: ['A & B A B'] }]);
+  });
+
+  it('leaves unknown entities untouched', () => {
+    const roots = parseXml('<members>A &foo; B</members>');
+    expect(roots).toEqual([{ tagName: 'members', children: ['A &foo; B'] }]);
+  });
+
+  it('parses self-closing elements', () => {
+    const roots = parseXml('<Package><version/></Package>');
+    expect(roots).toEqual([
+      {
+        tagName: 'Package',
+        children: [{ tagName: 'version', children: [] }],
+      },
+    ]);
+  });
+
+  it('parses multiple sibling root elements', () => {
+    const roots = parseXml('<Package></Package><Package></Package>');
+    expect(roots).toHaveLength(2);
+  });
+
+  it('parses nested elements with multiple children', () => {
+    const roots = parseXml(`<Package>
+  <types>
+    <members>A</members>
+    <members>B</members>
+    <name>ApexClass</name>
+  </types>
+</Package>`);
+    const [pkg] = roots;
+    const types = pkg.children.find((c) => typeof c !== 'string');
+    expect(types).toBeDefined();
+    expect((types as { tagName: string }).tagName).toBe('types');
+  });
+
+  it('throws on a mismatched closing tag', () => {
+    expect(() => parseXml('<Package><types></wrong></Package>')).toThrow(/mismatched closing tag/);
+  });
+
+  it('throws on an unterminated element', () => {
+    expect(() => parseXml('<Package><types>')).toThrow(/unterminated element/);
+  });
+
+  it('throws on an unterminated element with trailing text and no closing tag', () => {
+    expect(() => parseXml('<Package>trailing text')).toThrow(/unterminated element/);
+  });
+
+  it('throws on content outside the root element', () => {
+    expect(() => parseXml('text<Package></Package>')).toThrow(/unexpected content outside the root element/);
+  });
+
+  it('throws on an unterminated comment', () => {
+    expect(() => parseXml('<Package><!-- oops</Package>')).toThrow(/unterminated comment/);
+  });
+
+  it('throws on an unterminated processing instruction', () => {
+    expect(() => parseXml('<?xml version="1.0"')).toThrow(/unterminated processing instruction/);
+  });
+
+  it('throws on an unterminated closing tag', () => {
+    expect(() => parseXml('<Package></Package')).toThrow(/unterminated closing tag/);
+  });
+
+  it('throws on a missing attribute value', () => {
+    expect(() => parseXml('<Package xmlns=></Package>')).toThrow(/expected quoted attribute value/);
+  });
+
+  it('throws on an unterminated attribute value', () => {
+    expect(() => parseXml('<Package xmlns="unterminated></Package>')).toThrow(/unterminated attribute value/);
+  });
+
+  it('throws on a missing equals sign in an attribute', () => {
+    expect(() => parseXml('<Package xmlns "x"></Package>')).toThrow(/expected "=" in attribute/);
+  });
+
+  it('throws on unexpected end of input inside a tag', () => {
+    expect(() => parseXml('<Package xmlns="x"')).toThrow(/unexpected end of input inside a tag/);
+  });
+
+  it('throws on a missing element name', () => {
+    expect(() => parseXml('<>')).toThrow(/expected element name/);
+  });
+});

--- a/test/core/xmlParser.test.ts
+++ b/test/core/xmlParser.test.ts
@@ -124,4 +124,52 @@ describe('parseXml', () => {
   it('throws on a missing element name', () => {
     expect(() => parseXml('<>')).toThrow(/expected element name/);
   });
+
+  it('throws when a tag name runs to the end of input with no closing bracket', () => {
+    expect(() => parseXml('<foo')).toThrow(/unexpected end of input inside a tag/);
+  });
+
+  it('throws when an attribute name runs to the end of input with no "="', () => {
+    expect(() => parseXml('<Package xmlns')).toThrow(/expected "=" in attribute/);
+  });
+
+  it('skips whitespace around "=" in an attribute', () => {
+    const roots = parseXml('<Package xmlns = "http://soap.sforce.com/2006/04/metadata" ></Package>');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('parses a single-quoted attribute value', () => {
+    const roots = parseXml("<Package xmlns='http://soap.sforce.com/2006/04/metadata'></Package>");
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('does not mistake a "-->" sequence inside a preceding comment for the next one\'s closing', () => {
+    const roots = parseXml('<Package><!--x--><!--y--><version>1</version></Package>');
+    expect(roots).toEqual([
+      {
+        tagName: 'Package',
+        children: [{ tagName: 'version', children: ['1'] }],
+      },
+    ]);
+  });
+
+  it('does not mistake a "?>" sequence inside a preceding declaration for the next one\'s closing', () => {
+    const roots = parseXml('<?xml version="1.0"?><?xml version="1.0"?><Package></Package>');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('trims whitespace inside a closing tag', () => {
+    const roots = parseXml('<Package></Package >');
+    expect(roots).toEqual([{ tagName: 'Package', children: [] }]);
+  });
+
+  it('decodes the &apos; entity', () => {
+    const roots = parseXml('<members>It&apos;s</members>');
+    expect(roots).toEqual([{ tagName: 'members', children: ["It's"] }]);
+  });
+
+  it('decodes the &lt;, &gt;, and &quot; entities', () => {
+    const roots = parseXml('<members>&lt;a&gt; says &quot;hi&quot;</members>');
+    expect(roots).toEqual([{ tagName: 'members', children: ['<a> says "hi"'] }]);
+  });
 });

--- a/test/samples/package-special-chars.xml
+++ b/test/samples/package-special-chars.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <types>
+        <members>Account.Rating__c</members>
+        <members>Account.Sales_Region__c</members>
+        <name>CustomField</name>
+    </types>
+    <types>
+        <members>Sales &amp; Marketing</members>
+        <name>Group</name>
+    </types>
+    <version>61.0</version>
+</Package>


### PR DESCRIPTION
## Summary
- Drops the `txml` runtime dependency, replacing it with a minimal recursive-descent parser (`src/core/xmlParser.ts`) scoped to package.xml manifest structure (elements, attributes, text, entities, comments, `<?xml?>` declaration).
- Clears the way to package this plugin's core logic as a dependency-light GitHub Action.
- No behavior change: same `TNode`-shaped API surface consumed by `parseManifest.ts`, all existing parse/combine tests pass unmodified.

## Test plan
- [x] `vitest run --coverage` — 115/115 passing, 100% stmt/branch/line/func coverage
- [x] `biome check src test` — clean
- [x] `tsc` (src + test) — clean
- [x] `knip` — no unused deps
- [ ] mutation testing (runs in CI on this PR)